### PR TITLE
Added Celestial

### DIFF
--- a/src/Classes/Warlock/EldritchInvocations.json
+++ b/src/Classes/Warlock/EldritchInvocations.json
@@ -10,7 +10,7 @@
         ]
     },
     "ARMOR OF SHADOWS": {
-        "title": "Agonizing Blast",
+        "title": "Armor of Shadows",
         "description": "You can cast Mage Armor on yourself at will, without expending a spell slot or material components.",
         "spellAdded": "MAGE ARMOR"
     },

--- a/src/Classes/Warlock/Subclasses/Celestial/Celestial.ts
+++ b/src/Classes/Warlock/Subclasses/Celestial/Celestial.ts
@@ -1,0 +1,93 @@
+import { resourceLimits } from "worker_threads";
+import { ResourceTrait, ScalingTrait } from "../../../../Base/Interfaces";
+import { PlayerCharacter } from "../../../../Base/PlayerCharacter";
+import { LevelingParams } from "../../../../Classes/PlayerClass";
+import * as CelestialPatronDict from "./TheCelestial.json"
+
+export class Celestial {
+
+  static getFeature(level: string, featureName: string) {
+    return CelestialPatronDict["features"][level][featureName];
+  }
+
+  static getPatronSpells(pc: PlayerCharacter, level: string) {
+    pc.pcHelper.addSpells(Celestial.patronSpells[level], "charisma");
+  }
+
+  static upScale(pc: PlayerCharacter) {
+    const healing: ResourceTrait = pc.pcHelper.findResourceTraitByName("Healing Light");
+    healing.bonus++;
+  }
+
+  static upBoth(pc: PlayerCharacter) {
+    Celestial.upScale(pc);
+    const celestial: ScalingTrait = pc.pcHelper.findScalingTraitByName("Celestial Resilience");
+    celestial.bonus++;
+    celestial.points = pc.abilityScores.charisma.modifier.value;
+  }
+
+  static celestial1(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Celestial.getFeature("1", "BONUS CANTRIPS"));
+    pc.pcHelper.addFeatures(Celestial.getFeature("1", "HEALING LIGHT"));
+    pc.pcHelper.addSpells(["SACRED FLAME","LIGHT"],"charisma");
+    const healingtLight: ResourceTrait = {
+      title: "Healing Light",
+      description: "Your pool of resources for Healing Light",
+      dice: "1d6",
+      bonus: 2,
+      resourceMax: pc.abilityScores.charisma.modifier
+    }
+    Celestial.getPatronSpells(pc,"1");
+    pc.pcHelper.addResourceTraits(healingtLight);
+  }
+
+  static celestial3(pc: PlayerCharacter, params: LevelingParams) {
+    Celestial.getPatronSpells(pc,"2");
+    Celestial.upScale(pc);
+  }
+
+  static celestial5(pc: PlayerCharacter, params: LevelingParams) {
+    Celestial.getPatronSpells(pc,"3");
+    Celestial.upScale(pc);
+  }
+
+  static celestial6(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Celestial.getFeature("6", "RADIANT SOUL"));
+    Celestial.upScale(pc);
+  }
+
+  static celestial7(pc: PlayerCharacter, params: LevelingParams) {
+    Celestial.getPatronSpells(pc,"4");
+    Celestial.upScale(pc);
+  }
+
+  static celestial9(pc: PlayerCharacter, params: LevelingParams) {
+    Celestial.getPatronSpells(pc,"5");
+    Celestial.upScale(pc);
+  }
+
+  static celestial10(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Celestial.getFeature("10", "CELESTIAL RESILIENCE"));
+    const celestial: ScalingTrait = {
+      title: "Celestial Resilience",
+      description: "Temporary HP granted by Celestial Resilience, allies get half of bonus",
+      points: pc.abilityScores.charisma.modifier.value,
+      bonus: 10
+    }
+    pc.pcHelper.addScalingTraits(celestial);
+    Celestial.upScale(pc);
+  }
+
+  static celestial14(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Celestial.getFeature("14", "SEARING VENGEANCE"));
+    Celestial.upBoth(pc);
+  }
+
+  static patronSpells = {
+    "1": ["CURE WOUNDS", "GUIDING BOLT"],
+    "2": ["FLAMING SPHERE", "LESSER RESTORATION"],
+    "3": ["DAYLIGHT", "REVIVIFY"],
+    "4": ["GUARDIAN OF FAITH", "WALL OF FIRE"],
+    "5": ["FLAME STRIKE", "GREATER RESTORATION"]
+  }
+}

--- a/src/Classes/Warlock/Subclasses/Celestial/TheCelestial.json
+++ b/src/Classes/Warlock/Subclasses/Celestial/TheCelestial.json
@@ -1,0 +1,34 @@
+{
+  "title": "The Celestial", 
+  "description": "Your patron is a powerful being of the Upper Planes. You have bound yourself to an ancient empyrean, solar, ki-rin, unicorn, or other entity that resides in the planes of everlasting bliss. Your pact with that being allows you to experience the barest touch of the holy light that illuminates the multiverse. Being connected to such power can cause changes in your behavior and beliefs. You might find yourself driven to annihilate the undead, to defeat fiends, and to protect the innocent. At times, your heart might also be filled with a longing for the celestial realm of your patron, and a desire to wander that paradise for the rest of your days. But you know that your mission is among mortals for now, and that your pact binds you to bring light to the dark places of the world.", 
+  "features": {
+    "1": {
+      "BONUS CANTRIPS": {
+        "title": "Bonus Cantrips", 
+        "description": "At 1st level, you learn the sacred flame and light cantrips. They count as warlock cantrips for you, but they don't count against your number of cantrips known."
+      },
+      "HEALING LIGHT": {
+        "title": "Healing Light",
+        "description": "At 1st level, you gain the ability to channel celestial energy to heal wounds. You have a pool of d6s that you spend to fuel this healing. The number of dice in the pool equals 1 + your warlock level. As a bonus action, you can heal one creature you can see within 60 feet of you, spending dice from the pool. The maximum number of dice you can spend at once equals your Charisma modifier (minimum of one die). Roll the dice you spend, add them together, and restore a number of hit points equal to the total. Your pool regains all expended dice when you finish a long rest."
+      }
+    }, 
+    "6": {
+      "RADIANT SOUL": {
+        "title": "Radiant Soul", 
+        "description": "Starting at 6th level, your link to the Celestial allows you to serve as a conduit for radiant energy. You have resistance to radiant damage, and when you cast a spell that deals radiant or fire damage, you can add your Charisma modifier to one radiant or fire damage roll of that spell against one of its targets."
+      }
+    }, 
+    "10": {
+      "CELESTIAL RESILIENCE": {
+        "title": "Celestial Resilience", 
+        "description": "Starting at 10th level, you gain temporary hit points whenever you finish a short or long rest. These temporary hit points equal your warlock level + your Charisma modifier. Additionally, choose up to five creatures you can see at the end of the rest. Those creatures each gain temporary hit points equal to half your warlock level + your Charisma modifier."
+      }
+    }, 
+    "14": {
+      "SEARING VENGEANCE": {
+        "title": "Searing Vengeance", 
+        "description": "Starting at 14th level, the radiant energy you channel allows you to resist death. When you have to make a death saving throw at the start of your turn, you can instead spring back to your feet with a burst of radiant energy. You regain hit points equal to half your hit point maximum, and then you stand up if you so choose. Each creature of your choice that is within 30 feet of you takes radiant damage equal to 2d8 + your Charisma modifier, and it is blinded until the end of the current turn. Once you use this feature, you can't use it again until you finish a long rest."
+      }
+    }
+  }
+}

--- a/src/Classes/Warlock/Subclasses/WarlockSubclass.ts
+++ b/src/Classes/Warlock/Subclasses/WarlockSubclass.ts
@@ -2,6 +2,7 @@ import { Subclass } from "../../Subclass";
 import { Archfey } from "./Archfey/Archfey";
 import { Fiend } from "./Fiend/Fiend";
 import { GreatOldOne } from "./GreatOldOne/GreatOldOne";
+import { Celestial } from "./Celestial/Celestial";
 
 export class WarlockSubclass extends Subclass {
   constructor(subclass: string){
@@ -27,5 +28,27 @@ export class WarlockSubclass extends Subclass {
           "10": GreatOldOne.greatOldOne10,
           "14": GreatOldOne.greatOldOne14,
         },
+        CELESTIAL: { 
+          "1": Celestial.celestial1,
+          "2": Celestial.upScale,
+          "3": Celestial.celestial3,
+          "4": Celestial.upScale,
+          "5": Celestial.celestial5,
+          "6": Celestial.celestial6,
+          "7": Celestial.celestial7,
+          "8": Celestial.upScale,
+          "9": Celestial.celestial9,
+          "10": Celestial.celestial10,
+          "11": Celestial.upBoth,
+          "12": Celestial.upBoth,
+          "13": Celestial.upBoth,
+          "14": Celestial.celestial14,
+          "15": Celestial.upBoth,
+          "16": Celestial.upBoth,
+          "17": Celestial.upBoth,
+          "18": Celestial.upBoth,
+          "19": Celestial.upBoth,
+          "20": Celestial.upBoth,
+        }
       };
 }

--- a/src/Classes/Warlock/Warlock.ts
+++ b/src/Classes/Warlock/Warlock.ts
@@ -159,6 +159,7 @@ export class Warlock extends PlayerClass {
     this.handleWarlockSpellSelections(pc, params);
     pc.pcHelper.findResourceTraitByName("Pact Magic").resourceMax.value++;
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "2", params);
   }
 
   level3(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -169,11 +170,13 @@ export class Warlock extends PlayerClass {
     pactMagicSlots.level++;
     this.pactBoonHandler(pc, params.pactBoon);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "3", params);
   }
 
   level4(pc: PlayerCharacter, params: WarlockLevelingParams): void {
     this.handleWarlockSpellSelections(pc, params);
     pc.pcHelper.improveAbilityScores(params.abilityScoreImprovement);
+    this.subclassDriver(pc, "4", params);
   }
 
   level5(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -183,6 +186,7 @@ export class Warlock extends PlayerClass {
     ) as PactMagicSlots;
     pactMagicSlots.level++;
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "5", params);
   }
 
   level6(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -198,12 +202,14 @@ export class Warlock extends PlayerClass {
     ) as PactMagicSlots;
     pactMagicSlots.level++;
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "7", params);
   }
 
   level8(pc: PlayerCharacter, params: WarlockLevelingParams): void {
     this.handleWarlockSpellSelections(pc, params);
     pc.pcHelper.improveAbilityScores(params.abilityScoreImprovement);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "8", params);
   }
 
   level9(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -213,6 +219,7 @@ export class Warlock extends PlayerClass {
     ) as PactMagicSlots;
     pactMagicSlots.level++;
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "9", params);
   }
 
   level10(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -232,11 +239,13 @@ export class Warlock extends PlayerClass {
       [params.mysticArcanum]
     );
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "11", params);
   }
 
   level12(pc: PlayerCharacter, params: WarlockLevelingParams): void {
     pc.pcHelper.improveAbilityScores(params.abilityScoreImprovement);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "12", params);
   }
 
   level13(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -245,6 +254,7 @@ export class Warlock extends PlayerClass {
       .findFeatureTraitByName("MYSTIC ARCANUM")
       .choices.push(params.mysticArcanum);
       this.handleInvocationSelections(pc, params);
+      this.subclassDriver(pc, "13", params);
   }
 
   level14(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -258,11 +268,13 @@ export class Warlock extends PlayerClass {
       .findFeatureTraitByName("MYSTIC ARCANUM")
       .choices.push(params.mysticArcanum);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "15", params);
   }
 
   level16(pc: PlayerCharacter, params: WarlockLevelingParams): void {
     pc.pcHelper.improveAbilityScores(params.abilityScoreImprovement);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "16", params);
   }
 
   level17(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -272,6 +284,7 @@ export class Warlock extends PlayerClass {
       .findFeatureTraitByName("MYSTIC ARCANUM")
       .choices.push(params.mysticArcanum);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "17", params);
   }
 
   level18(pc: PlayerCharacter, params: WarlockLevelingParams): void {
@@ -282,11 +295,13 @@ export class Warlock extends PlayerClass {
     pc.pcHelper.improveAbilityScores(params.abilityScoreImprovement);
     this.handleWarlockSpellSelections(pc, params);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "18", params);
   }
 
   level20(pc: PlayerCharacter, params: WarlockLevelingParams): void {
     this.pushWarlockFeatures(pc, 20);
     this.handleInvocationSelections(pc, params);
+    this.subclassDriver(pc, "19", params);
   }
 
   private handleInvocationSelections(
@@ -335,12 +350,13 @@ export class Warlock extends PlayerClass {
     //determine proficiencies
     if (!pc.skills["deception"].proficient) {
       pc.skills["deception"].proficient = true;
-      inv.choices.push("deception");
+      // inv.choices.push("deception");
     }
     if (!pc.skills["persuasion"].proficient) {
       pc.skills["persuasion"].proficient = true;
-      inv.choices.push("persuasion");
+      // inv.choices.push("persuasion");
     }
+    inv.choices = ["deception","persuasion"];
     pc.pcHelper.addFeatures(inv);
   }
 


### PR DESCRIPTION
This one had a few problems.
Two different features have multiple restrictions/uses.
Healing light is a number of d6s equal to 1+ warlock level
you may use up to Charisma modifier number of dice at a time to heal someone
Celestial Resilience is based off warlock level, giving yourself temp hp, while up to 5 allies can get half your warlock level temp hp. These both get charisma mod as bonus.
Also, since patron spells aren't actually given to you but rather expand upon what you can choose, how do we want to do them? Warlock is not a preparation based class